### PR TITLE
Add files via upload

### DIFF
--- a/core/task_manager.lua
+++ b/core/task_manager.lua
@@ -1,7 +1,7 @@
 local settings = require "core.settings"
 local task_manager = {}
 local tasks = {}
-local current_task = nil
+local current_task = { name = "Idle" } -- Default state when no task is active
 local finished_time = 0
 
 function task_manager.set_finished_time(time)
@@ -18,7 +18,6 @@ end
 
 local last_call_time = 0.0
 function task_manager.execute_tasks()
-    
     local current_core_time = get_time_since_inject()
     if current_core_time - last_call_time < 0.2 then
         return -- quick ej slide frames
@@ -38,16 +37,15 @@ function task_manager.execute_tasks()
         end
     end
 
-    if not current_task then
-        current_task = { name = "Idle" } -- Default state when no task is active
-    end
+    -- The if statement has been removed, and current_task is always assigned
+    current_task = current_task or { name = "Idle" }
 end
 
 function task_manager.get_current_task()
-    return current_task or { name = "Idle" }
+    return current_task
 end
 
-local task_files = { "town_salvage" , "open_chests" , "horde" }
+local task_files = { "town_salvage" , "exit_horde" , "open_chests" , "horde" }
 for _, file in ipairs(task_files) do
     local task = require("tasks." .. file)
     task_manager.register_task(task)

--- a/core/tracker.lua
+++ b/core/tracker.lua
@@ -9,6 +9,7 @@ local tracker = {
     gold_chest_opened = false,
     finished_chest_looting = false,
     has_salvaged = false,
+    exit_horde_start_time = nil,
     has_entered = false
 }
 

--- a/tasks/exit_horde.lua
+++ b/tasks/exit_horde.lua
@@ -1,0 +1,33 @@
+local utils = require "core.utils"
+local settings = require "core.settings"
+local enums = require "data.enums"
+local tracker = require "core.tracker"
+
+local exit_horde_task = {
+    name = "Exit Horde",
+    shouldExecute = function()
+        return utils.player_in_zone("S05_BSK_Prototype02") and utils.player_on_quest(2023962) and tracker.finished_chest_looting == true
+    end,
+    
+    Execute = function()
+        local current_time = get_time_since_inject()
+
+        if not tracker.exit_horde_start_time then
+            tracker.exit_horde_start_time = current_time
+            console.print("Starting 10-second timer before exiting Horde")
+        end
+
+        if current_time - tracker.exit_horde_start_time >= 10 then
+            console.print("10-second timer completed. Resetting all dungeons")
+            reset_all_dungeons()
+            -- After resetting, set finished_chest_looting back to false
+            tracker.finished_chest_looting = false
+            -- Reset the exit_horde_start_time
+            tracker.exit_horde_start_time = nil
+        else
+            console.print(string.format("Waiting to exit Horde. Time remaining: %.2f seconds", 10 - (current_time - tracker.exit_horde_start_time)))
+        end
+    end
+}
+
+return exit_horde_task

--- a/tasks/horde.lua
+++ b/tasks/horde.lua
@@ -3,6 +3,7 @@ local enums      = require "data.enums"
 local settings   = require "core.settings"
 local navigation = require "core.navigation"
 local tracker    = require "core.tracker"
+local explorer   = require "core.explorer"
 
 local bomber = {
     enabled = false,
@@ -88,7 +89,9 @@ function bomber:use_all_spells()
 end
 
 function bomber:bomb_to(pos)
-    pathfinder.force_move_raw(pos)
+    --pathfinder.force_move_raw(pos)
+    explorer:set_custom_target(pos)
+    explorer:move_to_target()
 end
 
 function bomber:get_target()

--- a/tasks/open_chests.lua
+++ b/tasks/open_chests.lua
@@ -104,9 +104,18 @@ local open_chests_task = {
         end
         console.print(string.format("Execute finished at %.2f, tracker.ga_chest_opened: %s", 
                                     get_time_since_inject(), tostring(tracker.gold_chest_opened)))
+        
+        -- New code for 5-second cooldown before setting finished_chest_looting
         if tracker.ga_chest_opened and (tracker.peasant_chest_opening_stopped or tracker.gold_chest_opened) then
-            tracker.finished_chest_looting = true
-            console.print("All chest looting operations completed.")
+            if not tracker.finished_looting_start_time then
+                tracker.finished_looting_start_time = current_time
+                console.print(string.format("All chests opened. Starting 5-second cooldown at %.2f", tracker.finished_looting_start_time))
+            elseif current_time - tracker.finished_looting_start_time > 15 then
+                tracker.finished_chest_looting = true
+                console.print(string.format("5-second cooldown completed. All chest looting operations finished at %.2f", current_time))
+            else
+                console.print(string.format("Waiting for 5-second cooldown. Time elapsed: %.2f", current_time - tracker.finished_looting_start_time))
+            end
         end
     end
 }


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

-testing greptile
This pull request adds a new 'Exit Horde' task and modifies existing tasks and core functionality to support exiting the horde mode. The changes include updates to task management, tracking, and the horde task itself.

- New 'Exit Horde' task (tasks/exit_horde.lua) implements a 10-second delay before resetting dungeons
- Task manager (core/task_manager.lua) now handles 'Exit Pit' and 'Finish Pit' tasks separately
- Horde task (tasks/horde.lua) integrates 'explorer' module for improved navigation and adds detailed logging
- Open chests task (tasks/open_chests.lua) introduces a 15-second cooldown before marking chest looting as finished
- Tracker (core/tracker.lua) adds 'exit_horde_start_time' field, but it's not reset in the reset_chest_trackers() function

<!-- /greptile_comment -->