### PR TITLE
fixes

### DIFF
--- a/core/tracker.lua
+++ b/core/tracker.lua
@@ -25,6 +25,10 @@ function tracker.reset_chest_trackers()
     tracker.finished_chest_looting = false
 end
 
+function tracker.reset_dg_status()
+    tracker.horde_opened = false
+end
+
 function tracker.check_time(key, delay)
     local current_time = get_time_since_inject()
     if not tracker[key] or current_time - tracker[key] >= delay then

--- a/tasks/exit_horde.lua
+++ b/tasks/exit_horde.lua
@@ -25,6 +25,7 @@ local exit_horde_task = {
             tracker.finished_chest_looting = false
             -- Reset the exit_horde_start_time
             tracker.exit_horde_start_time = nil
+            tracker.reset_chest_trackers()
         else
             console.print(string.format("Waiting to exit Horde. Time remaining: %.2f seconds", 10 - (current_time - tracker.exit_horde_start_time)))
         end

--- a/tasks/start_dungeon.lua
+++ b/tasks/start_dungeon.lua
@@ -39,7 +39,7 @@ local start_dungeon_task = {
     end,
     Execute = function()
         local current_time = get_time_since_inject()
-        if current_time - stop_oh_yeah_wait_a_minute_mr_postman > 5 then
+        if current_time - stop_oh_yeah_wait_a_minute_mr_postman > 30 then
             console.print("Waiting period elapsed. Attempting to use Dungeon Sigil.")
             use_dungeon_sigil()
             stop_oh_yeah_wait_a_minute_mr_postman = current_time


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

-testing greptile
This pull request introduces changes to improve dungeon management and chest tracking in the HordeDev project. Here's a concise summary of the key modifications:

- Added `tracker.reset_dg_status()` function in `core/tracker.lua` to reset the horde_opened status
- Implemented `tracker.reset_chest_trackers()` call in `tasks/exit_horde.lua` for proper chest tracker reset on Horde exit
- Increased waiting period before using Dungeon Sigil from 5 to 30 seconds in `tasks/start_dungeon.lua`
- Critical error detected in `get_consumable_info` function in `core/tracker.lua`, returning false instead of info object
- Extended delay in `start_dungeon.lua` may significantly impact gameplay pacing and dungeon start frequency

<!-- /greptile_comment -->