### PR TITLE
bruh!

### DIFF
--- a/tasks/exit_horde.lua
+++ b/tasks/exit_horde.lua
@@ -25,7 +25,7 @@ local exit_horde_task = {
             tracker.finished_chest_looting = false
             -- Reset the exit_horde_start_time
             tracker.exit_horde_start_time = nil
-            tracker.reset_chest_trackers()
+            tracker.reset_dg_status()
         else
             console.print(string.format("Waiting to exit Horde. Time remaining: %.2f seconds", 10 - (current_time - tracker.exit_horde_start_time)))
         end


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

-testing greptile
This change modifies the exit_horde task to reset dungeon status instead of chest trackers when exiting the Horde mode.

- Replaced `tracker.reset_chest_trackers()` with `tracker.reset_dg_status()` in `/tasks/exit_horde.lua`
- `tracker.reset_dg_status()` only resets `tracker.horde_opened` to false in `/core/tracker.lua`
- This change may affect game state management, potentially leaving chest trackers in an inconsistent state
- The modification aligns with the "Create exit infernal horde task" item in the README's To-Do list
- Consider updating `tracker.reset_dg_status()` to include resetting chest trackers for consistency

<!-- /greptile_comment -->