### PR TITLE
testing loop - minor bugs

### DIFF
--- a/core/tracker.lua
+++ b/core/tracker.lua
@@ -9,10 +9,13 @@ local tracker = {
     gold_chest_opened = false,
     finished_chest_looting = false,
     has_salvaged = false,
-    exit_horde_start_time = nil,
+    exit_horde_start_time = 0,
     has_entered = false,
+    start_dungeon_time = nil,
     horde_opened = false,
-    first_run = false
+    first_run = false,
+    exit_horde_completion_time = 0,
+    exit_horde_completed = true
 }
 
 function tracker.reset_chest_trackers()
@@ -25,9 +28,6 @@ function tracker.reset_chest_trackers()
     tracker.finished_chest_looting = false
 end
 
-function tracker.reset_dg_status()
-    tracker.horde_opened = false
-end
 
 function tracker.check_time(key, delay)
     local current_time = get_time_since_inject()

--- a/tasks/exit_horde.lua
+++ b/tasks/exit_horde.lua
@@ -6,28 +6,30 @@ local tracker = require "core.tracker"
 local exit_horde_task = {
     name = "Exit Horde",
     shouldExecute = function()
-        return utils.player_in_zone("S05_BSK_Prototype02") and utils.player_on_quest(2023962) and tracker.finished_chest_looting == true
+        return utils.player_in_zone("S05_BSK_Prototype02") and utils.player_on_quest(2023962) and tracker.gold_chest_opened == true and tracker.exit_horde_completed
     end,
     
     Execute = function()
         local current_time = get_time_since_inject()
 
         if not tracker.exit_horde_start_time then
-            tracker.exit_horde_start_time = current_time
-            reset_all_dungeons()
+            tracker.gold_chest_opened = true
             console.print("Starting 10-second timer before exiting Horde")
+            tracker.exit_horde_start_time = current_time
         end
-
-        if current_time - tracker.exit_horde_start_time >= 10 then
+       
+        local elapsed_time = current_time - tracker.exit_horde_start_time
+        if elapsed_time >= 10 then
             console.print("10-second timer completed. Resetting all dungeons")
-            --reset_all_dungeons()
-            -- After resetting, set finished_chest_looting back to false
-            tracker.finished_chest_looting = false
-            -- Reset the exit_horde_start_time
+            reset_all_dungeons()
             tracker.exit_horde_start_time = nil
-            tracker.reset_dg_status()
+            tracker.exit_horde_completed = true  -- Neue Zeile
+            tracker.exit_horde_completion_time = current_time  -- Neue Zeile
+            tracker.horde_opened = false
+            tracker.gold_chest_opened = false
+            tracker.start_dungeon_time = nil
         else
-            console.print(string.format("Waiting to exit Horde. Time remaining: %.2f seconds", 10 - (current_time - tracker.exit_horde_start_time)))
+            console.print(string.format("Waiting to exit Horde. Time remaining: %.2f seconds", 10 - elapsed_time))
         end
     end
 }

--- a/tasks/open_chests.lua
+++ b/tasks/open_chests.lua
@@ -144,3 +144,12 @@ local open_chests_task = {
 }
 
 return open_chests_task
+
+
+
+
+
+
+
+
+

--- a/tasks/start_dungeon.lua
+++ b/tasks/start_dungeon.lua
@@ -1,8 +1,8 @@
+
 local utils = require "core.utils"
 local enums = require "data.enums"
 local tracker = require "core.tracker"
 
-local stop_oh_yeah_wait_a_minute_mr_postman = get_time_since_inject()
 
 local function use_dungeon_sigil()
     if tracker.horde_opened then
@@ -35,16 +35,25 @@ end
 local start_dungeon_task = {
     name = "Start Dungeon",
     shouldExecute = function()
-        return not utils.player_in_zone("S05_BSK_Prototype02") and not tracker.horde_opened and (tracker.finished_chest_looting or not tracker.first_run)
+        return not utils.player_in_zone("S05_BSK_Prototype02") 
+            and not tracker.horde_opened 
+            and (tracker.gold_chest_opened or not tracker.first_run)
+            and tracker.exit_horde_completed  -- Neue Bedingung        
     end,
+
     Execute = function()
         local current_time = get_time_since_inject()
-        if current_time - stop_oh_yeah_wait_a_minute_mr_postman > 30 then
-            console.print("Waiting period elapsed. Attempting to use Dungeon Sigil.")
-            use_dungeon_sigil()
-            stop_oh_yeah_wait_a_minute_mr_postman = current_time
+        if not tracker.start_dungeon_time then
+           console.print("Stay a while and listen")
+           tracker.start_dungeon_time = current_time
+        end
+
+        local elapsed_time = current_time - tracker.start_dungeon_time
+        if elapsed_time >= 15 then
+           console.print("Time to farm! Attempting to use Dungeon Sigil")
+           use_dungeon_sigil()
         else
-            console.print(string.format("Waiting before using Dungeon Sigil... %.2f seconds remaining.", 5 - (current_time - stop_oh_yeah_wait_a_minute_mr_postman)))
+            console.print(string.format("Waiting before using Dungeon Sigil... %.2f seconds remaining.", 10 - elapsed_time))
         end
     end
 }

--- a/tasks/town_salvage.lua
+++ b/tasks/town_salvage.lua
@@ -24,6 +24,7 @@ local task = {
 
         local success, error = pcall(function()
             if not utils.player_in_zone("Scos_Cerrigar") and get_local_player():get_item_count() >= 1 then
+                explorer:clear_path_and_target()
                 teleport_to_waypoint(waypoints_enum.CERRIGAR)
                 return true  -- Exit the function and wait for next tick
             end


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

-testing greptile
This pull request modifies several key components of the Infernal Horde automation script, focusing on improving the flow and timing of various game actions.

- Added new tracker variables in `core/tracker.lua` for managing horde events and dungeon starts
- Modified `tasks/exit_horde.lua` to include new execution conditions and update tracker variables
- Implemented a 15-second wait period in `tasks/start_dungeon.lua` before using the Dungeon Sigil
- Adjusted the salvaging process in `tasks/town_salvage.lua`, including clearing path and target before teleporting
- Potential timing and logic flow issues introduced, particularly in the interaction between exit_horde and start_dungeon tasks

<!-- /greptile_comment -->