### PR TITLE
loop 2 - flag tweaks, homestretch

### DIFF
--- a/core/task_manager.lua
+++ b/core/task_manager.lua
@@ -45,7 +45,7 @@ function task_manager.get_current_task()
     return current_task
 end
 
-local task_files = { "town_salvage" , "exit_horde" , "open_chests" , "horde", "start_dungeon", "enter_horde" }
+local task_files = { "town_salvage" , "open_chests" , "exit_horde" ,"start_dungeon", "enter_horde", "horde",  }
 for _, file in ipairs(task_files) do
     local task = require("tasks." .. file)
     task_manager.register_task(task)

--- a/tasks/enter_horde.lua
+++ b/tasks/enter_horde.lua
@@ -18,7 +18,7 @@ end
 local enter_horde_task = {
     name = "Enter Horde",
     shouldExecute = function()
-        return not utils.player_in_zone("S05_BSK_Prototype02") and tracker.horde_opened
+        return utils.player_in_zone("Kehj_Caldeum") and tracker.horde_opened
     end,
     Execute = function()
         enter_horde()

--- a/tasks/exit_horde.lua
+++ b/tasks/exit_horde.lua
@@ -6,7 +6,7 @@ local tracker = require "core.tracker"
 local exit_horde_task = {
     name = "Exit Horde",
     shouldExecute = function()
-        return utils.player_in_zone("S05_BSK_Prototype02") and utils.player_on_quest(2023962) and tracker.gold_chest_opened == true and tracker.exit_horde_completed
+        return utils.player_in_zone("S05_BSK_Prototype02") and utils.player_on_quest(2023962) and tracker.gold_chest_opened == true
     end,
     
     Execute = function()
@@ -23,7 +23,6 @@ local exit_horde_task = {
             console.print("10-second timer completed. Resetting all dungeons")
             reset_all_dungeons()
             tracker.exit_horde_start_time = nil
-            tracker.exit_horde_completed = true  -- Neue Zeile
             tracker.exit_horde_completion_time = current_time  -- Neue Zeile
             tracker.horde_opened = false
             tracker.gold_chest_opened = false

--- a/tasks/horde.lua
+++ b/tasks/horde.lua
@@ -168,15 +168,14 @@ function bomber:get_target()
 end
 
 local pylons = {
-    "MeteoricHellborne",       -- Hellfire now spawns Hellborne, +1 Aether
     "SkulkingHellborne",       -- Hellborne Hunting You, Hellborne +1 Aether
     "SurgingHellborne",        -- +1 Hellborne when Spawned, Hellborne Grant +1 Aether
-    "EmpoweredHellborne",      -- Hellborne +25% Damage, Hellborne grant +1 Aether
-    "BlisteringHordes",        -- Normal Monster Spawn Aether Events 50% Faster
-    "InfernalLords",           -- Aether Lords Now Spawn, they grant +3 Aether
-    "SurgingElites",           -- Chance for Elite Doubled, Aether Fiends grant +1 Aether
     "RagingHellfire",          -- Hellfire rains upon you, at the end of each wave spawn 1-3 Aether
-    "InfernalStalker",         -- An Infernal demon has your scent, Slay it to gain +25 Aether
+    "MeteoricHellborne",       -- Hellfire now spawns Hellborne, +1 Aether
+    "EmpoweredHellborne",      -- Hellborne +25% Damage, Hellborne grant +1 Aether
+    "InvigoratingHellborne",   -- Hellborne Damage +25%, Slaying Hellborne Invigorates you
+    "BlisteringHordes",        -- Normal Monster Spawn Aether Events 50% Faster
+    "SurgingElites",           -- Chance for Elite Doubled, Aether Fiends grant +1 Aether
     "ThrivingMasses",          -- Masses deal unavoidable damage, Wave start, spawn an Aetheric Mass
     "GestatingMasses",         -- Masses spawn an Aether lord on Death, Aether Lords Grant +3 Aether
     "EmpoweredMasses",         -- Aetheric Mass damage: +25%, Aetheric Mass grants +1 Aether
@@ -187,12 +186,13 @@ local pylons = {
     "ReduceAllResistance",     -- Reduce All Resist -10%, Council grants +15 Aether
     "DeadlySpires",            -- Soulspires Drain Health, Soulspires grant +2 Aether
     "UnstoppableElites",       -- Elites are Unstoppable, Aether Fiends grant +1 Aether
-    "InvigoratingHellborne",   -- Hellborne Damage +25%, Slaying Hellborne Invigorates you
     "CorruptingSpires",        -- Soulspires empower nearby foes, they also pull enemies inward
     "UnstableFiends",          -- Elite Damage +25%, Aether Fiends explode and damage FOES
     "AetherRush",              -- Normal Monsters Damage +25%, Gathering Aether Increases Movement Speed
     "EnergizingMasses",        -- Slaying Aetheric Masses slow you, While slowed this way, you have UNLIMITED RESOURCES
     "GreedySpires",            -- Soulspire requires 2x kills, Soulspires grant 2x Aether
+    "InfernalLords",           -- Aether Lords Now Spawn, they grant +3 Aether
+    "InfernalStalker",         -- An Infernal demon has your scent, Slay it to gain +25 Aether
 }
 
 function bomber:get_pylons()

--- a/tasks/open_chests.lua
+++ b/tasks/open_chests.lua
@@ -17,7 +17,7 @@ end
 local open_chests_task = {
     name = "Open Chests",
     shouldExecute = function()
-        return utils.player_in_zone("S05_BSK_Prototype02") and utils.get_stash() ~= nil
+        return utils.player_in_zone("S05_BSK_Prototype02") and utils.get_stash() ~= nil and not tracker.finished_chest_looting
     end,
     
     Execute = function()

--- a/tasks/start_dungeon.lua
+++ b/tasks/start_dungeon.lua
@@ -35,10 +35,8 @@ end
 local start_dungeon_task = {
     name = "Start Dungeon",
     shouldExecute = function()
-        return not utils.player_in_zone("S05_BSK_Prototype02") 
-            and not tracker.horde_opened 
-            and (tracker.gold_chest_opened or not tracker.first_run)
-            and tracker.exit_horde_completed  -- Neue Bedingung        
+        return utils.player_in_zone("Kehj_Caldeum") 
+            and not tracker.horde_opened         
     end,
 
     Execute = function()


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

-testing greptile
This pull request makes several changes to task execution and game logic in the HordeDev project. Here's a concise summary of the key modifications and potential implications:

1. Task reordering in core/task_manager.lua may affect execution priority, with 'open_chests' now having higher precedence and 'horde' moved to the end.

2. Simplified condition for enter_horde.lua task execution, now only checking for player location and horde opened status.

3. Removal of exit_horde_completed flag in exit_horde.lua, potentially impacting Horde exit process flow control.

4. Addition of new pylons and reordering of existing ones in horde.lua, which could alter pylon priority in game logic.

5. Implementation of Aether bomb collection and cooldown period after chest opening in open_chests.lua, enhancing the chest looting process.

<!-- /greptile_comment -->