### PR TITLE
4 LOOPS 

### DIFF
--- a/tasks/open_chests.lua
+++ b/tasks/open_chests.lua
@@ -17,7 +17,7 @@ end
 local open_chests_task = {
     name = "Open Chests",
     shouldExecute = function()
-        return utils.player_in_zone("S05_BSK_Prototype02") and utils.get_stash() ~= nil and not tracker.finished_chest_looting
+        return utils.player_in_zone("S05_BSK_Prototype02") and utils.get_stash() ~= nil and not tracker.gold_chest_opened
     end,
     
     Execute = function()

--- a/tasks/start_dungeon.lua
+++ b/tasks/start_dungeon.lua
@@ -3,6 +3,17 @@ local utils = require "core.utils"
 local enums = require "data.enums"
 local tracker = require "core.tracker"
 
+local function reset_chest_flags()
+    tracker.ga_chest_open_time = 0
+    tracker.ga_chest_opened = false
+    tracker.peasant_chest_open_time = 0
+    tracker.peasant_chest_opening_stopped = false
+    tracker.gold_chest_open_time = 0
+    tracker.gold_chest_opened = false
+    tracker.finished_chest_looting = false
+    tracker.finished_looting_start_time = nil
+    console.print("Chest flags reset for new dungeon run")
+end
 
 local function use_dungeon_sigil()
     if tracker.horde_opened then


### PR DESCRIPTION
fixed random flag stuff 

<!-- greptile_comment -->

## Greptile Summary

-testing greptile
This pull request modifies the chest opening logic in the HordeDev project, focusing on changes in the open_chests.lua and start_dungeon.lua files.

- Updated shouldExecute condition in open_chests_task from 'not tracker.finished_chest_looting' to 'not tracker.gold_chest_opened', potentially altering chest opening behavior
- Added reset_chest_flags() function in start_dungeon.lua, but it's not called anywhere, rendering it ineffective
- Modified use_dungeon_sigil() function and start_dungeon_task with potential implementation issues
- Changed chest opening logic, including handling of different chest types and cooldown periods
- Introduced additional logging for debugging chest opening process

<!-- /greptile_comment -->