### PR TITLE
Add files via upload

### DIFF
--- a/tasks/start_dungeon.lua
+++ b/tasks/start_dungeon.lua
@@ -1,4 +1,3 @@
-
 local utils = require "core.utils"
 local enums = require "data.enums"
 local tracker = require "core.tracker"
@@ -53,14 +52,15 @@ local start_dungeon_task = {
     Execute = function()
         local current_time = get_time_since_inject()
         if not tracker.start_dungeon_time then
-           console.print("Stay a while and listen")
-           tracker.start_dungeon_time = current_time
+            console.print("Stay a while and listen")
+            tracker.start_dungeon_time = current_time
         end
 
         local elapsed_time = current_time - tracker.start_dungeon_time
         if elapsed_time >= 15 then
-           console.print("Time to farm! Attempting to use Dungeon Sigil")
-           use_dungeon_sigil()
+            console.print("Time to farm! Attempting to use Dungeon Sigil")
+            reset_chest_flags() -- Reset chest flags at the start of the dungeon
+            use_dungeon_sigil()
         else
             console.print(string.format("Waiting before using Dungeon Sigil... %.2f seconds remaining.", 10 - elapsed_time))
         end


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

-testing greptile
This PR introduces a new function `reset_chest_flags()` to reset chest-related flags at the start of each dungeon run in the Infernal Horde script.

- Added `reset_chest_flags()` function in `/tasks/start_dungeon.lua` to reset all chest-related tracker variables
- Integrated `reset_chest_flags()` call in `start_dungeon_task.Execute()` before using the Dungeon Sigil
- Improved code formatting and removed an empty line at the beginning of the file

<!-- /greptile_comment -->