### PR TITLE
added flag reset to horde task - should fix failed due to death

### DIFF
--- a/tasks/horde.lua
+++ b/tasks/horde.lua
@@ -386,6 +386,7 @@ local task = {
     end,
     
     Execute = function()
+        tracker.horde_opened = false
         bomber:main_pulse()
     end
 }


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

-testing greptile
Added a flag reset in the horde task to potentially fix dungeon failures due to player death.

- Reset `tracker.horde_opened` flag at the start of the horde task's Execute function
- This change aims to ensure proper state tracking after player death
- May prevent issues related to incorrect horde state persistence

<!-- /greptile_comment -->